### PR TITLE
create different lowerings for different use types

### DIFF
--- a/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/AddressLoweringByUsePhase.java
+++ b/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/AddressLoweringByUsePhase.java
@@ -94,8 +94,13 @@ public class AddressLoweringByUsePhase extends Phase {
             // the lowered address amy already be a replacement
             // in which case we want to use it not delete it!
             if (lowered != address) {
-                address.replaceAtUsages(lowered);
-                GraphUtil.killWithUnusedFloatingInputs(address);
+                // replace original with lowered at this usage only
+                // n.b. lowered is added unique so repeat lowerings will elide
+                node.replaceFirstInput(address, lowered);
+                // if that was the last reference we can kill the old (dead) node
+                if (address.hasNoUsages()) {
+                    GraphUtil.killWithUnusedFloatingInputs(address);
+                }
             }
         }
 


### PR DESCRIPTION
The issue:
The current AArhc64 address lowering assumes each use of an address employs the same type for the loaded datum. In rare cases this assumption is invalid because an address is shared by two loads with different types. In particular, this manifests when loading an int from a DirectByteBuffer at an odd address. The problem can be seen when running netbeans, where reads of mapped file data occasionally fail when an integer datum is located at an odd offset.

Diagnosis:
The generated code for Unsafe.getIntUnaligned
```
    public final int getIntUnaligned(Object o, long offset) {
        if ((offset & 3) == 0) {
            return getInt(o, offset);
        } else if ((offset & 1) == 0) {
            return makeInt(getShort(o, offset),
                           getShort(o, offset + 2)); // base + const offset 2
        } else {
            return makeInt(getByte(o, offset),
                           getByte(o, offset + 1),
                           getByte(o, offset + 2), // base + const offset 2
                           getByte(o, offset + 3));
        }
    }
```
results in a short read and a byte read from the same base address both with offset 2. The RawAddress shared by both reads is currently lowered to an AArch64 address with displacement=2 and scalefactor=2, the latter because the first usage is a read with type short (scalefactor = transfer unit size). This leads to the short read being generated with the correct embedded offset 1 and the byte read generated with incorrect byte offset 1.

Fix:
The patch replaces an address at each usage with a lowering determined by the use type. So, in the above example each read gets its own AArch64 address, the first with scalefactor-=2 and the secodn with scalefactor=1.

Testing:
The byte buffer read errros re-appeared consistently when running netbeans after I pulled in the AArch64 address lowering change from the master repo. I tracked down the problem to a bad offset in the relevant ldrb instruction in the code generated for Unsafe,getItUnaligned.

After applying this patch netbeans no longer suffered read errors. A dump of the generated code for Unsafe,getItUnaligned showed that the correct offset was being employed.