### PR TITLE
Aarch64 tbz patch

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
@@ -95,6 +95,7 @@ import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.STXR
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.SUB;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.SUBS;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.TBZ;
+import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.TBNZ;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.UBFM;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.UDIV;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.InstructionType.FP32;
@@ -477,6 +478,7 @@ public abstract class AArch64Assembler extends Assembler {
         CBNZ(0x01000000),
         CBZ(0x00000000),
         TBZ(0x36000000),
+        TBNZ(0x37000000),
 
         B(0x00000000),
         BL(0x80000000),
@@ -811,17 +813,74 @@ public abstract class AArch64Assembler extends Assembler {
     }
 
     /**
+     * Test a single bit and branch if the bit is nonzero.
+     *
+     * @param reg general purpose register. May not be null, zero-register or stackpointer.
+     * @param uimm6 Unsigned 6-bit bit index.
+     * @param imm16 signed 16 bit offset
+     */
+    protected void tbnz(Register reg, int uimm6, int imm16) {
+        tbnz(reg, uimm6, imm16, -1);
+    }
+
+    /**
      * Test a single bit and branch if the bit is zero.
      *
      * @param reg general purpose register. May not be null, zero-register or stackpointer.
-     * @param size Instruction size in bits. Should be either 32 or 64.
      * @param uimm6 Unsigned 6-bit bit index.
+     * @param imm16 signed 16 bit offset
+     */
+    protected void tbz(Register reg, int uimm6, int imm16) {
+        tbz(reg, uimm6, imm16, -1);
+    }
+
+    /**
+     * Test a single bit and branch if the bit is nonzero.
+     *
+     * @param reg general purpose register. May not be null, zero-register or stackpointer.
+     * @param uimm6 Unsigned 6-bit bit index.
+     * @param imm16 signed 16 bit offset
      * @param pos Position at which instruction is inserted into buffer. -1 means insert at end.
      */
-    protected void tbz(int size, Register reg, int uimm6, int pos) {
+    protected void tbnz(Register reg, int uimm6, int imm16, int pos) {
         assert reg.getRegisterCategory().equals(CPU);
+        assert NumUtil.isUnsignedNbit(6, uimm6);
+        assert NumUtil.isSignedNbit(18, imm16);
+        assert (imm16 & 3) == 0;
+        // size bit is overloaded as top bit of uimm6 bit index
+        int size = (((uimm6 >> 5) & 1) == 0 ? 32 : 64);
+        // remaining 5 bits are encoded lower down
+        int uimm5 = uimm6 >> 1;
+        int offset = (imm16 & NumUtil.getNbitNumberInt(16)) >> 2;
         InstructionType type = generalFromSize(size);
-        int encoding = type.encoding | TBZ.encoding | (uimm6 << 18) | rd(reg);
+        int encoding = type.encoding | TBNZ.encoding | (uimm5 << 19) | (offset << 5) | rd(reg);
+        if (pos == -1) {
+            emitInt(encoding);
+        } else {
+            emitInt(encoding, pos);
+        }
+    }
+
+    /**
+     * Test a single bit and branch if the bit is zero.
+     *
+     * @param reg general purpose register. May not be null, zero-register or stackpointer.
+     * @param uimm6 Unsigned 6-bit bit index.
+     * @param imm16 signed 16 bit offset
+     * @param pos Position at which instruction is inserted into buffer. -1 means insert at end.
+     */
+    protected void tbz(Register reg, int uimm6, int imm16, int pos) {
+        assert reg.getRegisterCategory().equals(CPU);
+        assert NumUtil.isUnsignedNbit(6, uimm6);
+        assert NumUtil.isSignedNbit(18, imm16);
+        assert (imm16 & 3) == 0;
+        // size bit is overloaded as top bit of uimm6 bit index
+        int size = (((uimm6 >> 5) & 1) == 0 ? 32 : 64);
+        // remaining 5 bits are encoded lower down
+        int uimm5 = uimm6 >> 1;
+        int offset = (imm16 & NumUtil.getNbitNumberInt(16)) >> 2;
+        InstructionType type = generalFromSize(size);
+        int encoding = type.encoding | TBZ.encoding | (uimm5 << 19) | (offset << 5) | rd(reg);
         if (pos == -1) {
             emitInt(encoding);
         } else {

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
@@ -1216,8 +1216,10 @@ public class AArch64MacroAssembler extends AArch64Assembler {
         BRANCH_UNCONDITIONALLY(0x1),
         BRANCH_NONZERO(0x2),
         BRANCH_ZERO(0x3),
-        JUMP_ADDRESS(0x4),
-        ADR(0x5);
+        BRANCH_BIT_NONZERO(0x4),
+        BRANCH_BIT_ZERO(0x5),
+        JUMP_ADDRESS(0x6),
+        ADR(0x7);
 
         /**
          * Offset by which additional information for branch conditionally, branch zero and branch
@@ -1295,22 +1297,42 @@ public class AArch64MacroAssembler extends AArch64Assembler {
     }
 
     /**
-     * Test a single bit and branch if the bit is zero.
+     * Test a single bit and branch if the bit is nonzero.
      *
      * @param cmp general purpose register. May not be null, zero-register or stackpointer.
-     * @param size Instruction size in bits. Should be either 32 or 64.
      * @param uimm6 Unsigned 6-bit bit index.
      * @param label Can only handle 21-bit word-aligned offsets for now. May be unbound. Non null.
      */
-    public void tbz(int size, Register cmp, int uimm6, Label label) {
+    public void tbnz(Register cmp, int uimm6, Label label) {
+        assert NumUtil.isUnsignedNbit(6, uimm6);
         if (label.isBound()) {
             int offset = label.position() - position();
-            super.tbz(size, cmp, uimm6, offset);
+            super.tbnz(cmp, uimm6, offset);
         } else {
             label.addPatchAt(position());
-            int regEncoding = cmp.encoding << (PatchLabelKind.INFORMATION_OFFSET + 1);
-            int sizeEncoding = (size == 64 ? 1 : 0) << PatchLabelKind.INFORMATION_OFFSET;
-            emitInt(PatchLabelKind.BRANCH_CONDITIONALLY.encoding | regEncoding | sizeEncoding);
+            int indexEncoding = uimm6 << PatchLabelKind.INFORMATION_OFFSET;
+            int regEncoding = cmp.encoding << (PatchLabelKind.INFORMATION_OFFSET + 6);
+            emitInt(PatchLabelKind.BRANCH_BIT_NONZERO.encoding | indexEncoding | regEncoding);
+        }
+    }
+
+    /**
+     * Test a single bit and branch if the bit is zero.
+     *
+     * @param cmp general purpose register. May not be null, zero-register or stackpointer.
+     * @param uimm6 Unsigned 6-bit bit index.
+     * @param label Can only handle 21-bit word-aligned offsets for now. May be unbound. Non null.
+     */
+    public void tbz(Register cmp, int uimm6, Label label) {
+        assert NumUtil.isUnsignedNbit(6, uimm6);
+        if (label.isBound()) {
+            int offset = label.position() - position();
+            super.tbz(cmp, uimm6, offset);
+        } else {
+            label.addPatchAt(position());
+            int indexEncoding = uimm6 << PatchLabelKind.INFORMATION_OFFSET;
+            int regEncoding = cmp.encoding << (PatchLabelKind.INFORMATION_OFFSET + 6);
+            emitInt(PatchLabelKind.BRANCH_BIT_ZERO.encoding | indexEncoding | regEncoding);
         }
     }
 
@@ -1490,6 +1512,22 @@ public class AArch64MacroAssembler extends AArch64Assembler {
                         break;
                     case BRANCH_ZERO:
                         super.cbz(size, reg, branchOffset, branch);
+                        break;
+                }
+                break;
+            }
+            case BRANCH_BIT_NONZERO:
+            case BRANCH_BIT_ZERO: {
+                int information = instruction >>> PatchLabelKind.INFORMATION_OFFSET;
+                int sizeEncoding = information & NumUtil.getNbitNumberInt(6);
+                int regEncoding = information >>> 6;
+                Register reg = AArch64.cpuRegisters.get(regEncoding);
+                switch (type) {
+                    case BRANCH_BIT_NONZERO:
+                        super.tbnz(reg, sizeEncoding, branchOffset, branch);
+                        break;
+                    case BRANCH_BIT_ZERO:
+                        super.tbz(reg, sizeEncoding, branchOffset, branch);
                         break;
                 }
                 break;

--- a/compiler/src/org.graalvm.compiler.truffle.hotspot.aarch64/src/org/graalvm/compiler/truffle/hotspot/aarch64/AArch64OptimizedCallTargetInstumentationFactory.java
+++ b/compiler/src/org.graalvm.compiler.truffle.hotspot.aarch64/src/org/graalvm/compiler/truffle/hotspot/aarch64/AArch64OptimizedCallTargetInstumentationFactory.java
@@ -70,7 +70,7 @@ public class AArch64OptimizedCallTargetInstumentationFactory extends OptimizedCa
                     masm.cbz(64, spillRegister, doProlog);
                     // TODO(alexpro): Temporarily disable this fix for GR-4454 until this is tested.
                     if (TruffleCompiler.Options.AArch64EntryPointTagging.getValue(options)) {
-                        masm.tbz(64, spillRegister, 0, doProlog);
+                        masm.tbz(spillRegister, 0, doProlog);
                         masm.eor(64, spillRegister, spillRegister, 1);
                     }
                     masm.jmp(spillRegister);

--- a/compiler/src/org.graalvm.compiler.truffle.hotspot.aarch64/src/org/graalvm/compiler/truffle/hotspot/aarch64/AArch64OptimizedCallTargetInstumentationFactory.java
+++ b/compiler/src/org.graalvm.compiler.truffle.hotspot.aarch64/src/org/graalvm/compiler/truffle/hotspot/aarch64/AArch64OptimizedCallTargetInstumentationFactory.java
@@ -68,11 +68,8 @@ public class AArch64OptimizedCallTargetInstumentationFactory extends OptimizedCa
                     masm.dmb(LOAD_LOAD);
                     masm.dmb(LOAD_STORE);
                     masm.cbz(64, spillRegister, doProlog);
-                    // TODO(alexpro): Temporarily disable this fix for GR-4454 until this is tested.
-                    if (TruffleCompiler.Options.AArch64EntryPointTagging.getValue(options)) {
-                        masm.tbz(spillRegister, 0, doProlog);
-                        masm.eor(64, spillRegister, spillRegister, 1);
-                    }
+                    masm.tbz(spillRegister, 0, doProlog);
+                    masm.eor(64, spillRegister, spillRegister, 1);
                     masm.jmp(spillRegister);
                     masm.nop();
                     masm.bind(doProlog);

--- a/compiler/src/org.graalvm.compiler.truffle/src/org/graalvm/compiler/truffle/TruffleCompiler.java
+++ b/compiler/src/org.graalvm.compiler.truffle/src/org/graalvm/compiler/truffle/TruffleCompiler.java
@@ -95,13 +95,6 @@ public abstract class TruffleCompiler {
     };
     // @formatter:on
 
-    public static class Options {
-        //@formatter:off
-        @Option(help = "Enable the entry point tagging on AArch64, used for safe publishing of Truffle entry points.")
-        public static final OptionKey<Boolean> AArch64EntryPointTagging = new OptionKey<>(false);
-        //@formatter:on
-    }
-
     public static final OptimisticOptimizations Optimizations = OptimisticOptimizations.ALL.remove(OptimisticOptimizations.Optimization.UseExceptionProbability,
                     OptimisticOptimizations.Optimization.RemoveNeverExecutedCode, OptimisticOptimizations.Optimization.UseTypeCheckedInlining, OptimisticOptimizations.Optimization.UseTypeCheckHints);
 
@@ -245,9 +238,7 @@ public abstract class TruffleCompiler {
             a.getAssumption().registerInstalledCode(installedCode);
         }
 
-        if (!providers.getCodeCache().getTarget().arch.getName().equals("aarch64") || Options.AArch64EntryPointTagging.getValue(getOptions())) {
-            installedCode.releaseEntryPoint();
-        }
+        installedCode.releaseEntryPoint();
 
         return result;
     }


### PR DESCRIPTION
This patch fixes a problem introduced into AArch64 by a previous truffle compiler fix.

Testing:
The patch fixes all the unit tests which were failing because of a broken tbz implementation.

n.b. 12 CountedLoop tests are still failing but that is due to an unrelated error to do with missing frame state for a SafeSignedDiv node