### PR TITLE
avoid asserts over missing before state when generating safe Div/Rem nodes on AArch64

### DIFF
--- a/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64IntegerArithmeticSnippets.java
+++ b/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64IntegerArithmeticSnippets.java
@@ -206,6 +206,7 @@ public class AArch64IntegerArithmeticSnippets extends AbstractTemplates implemen
         protected SafeSignedDivNode(ValueNode x, ValueNode y) {
             super(TYPE, x, y);
         }
+
         @Override
         public void generate(NodeLIRBuilderTool gen) {
             // override to ensure we always pass a null frame state
@@ -221,6 +222,7 @@ public class AArch64IntegerArithmeticSnippets extends AbstractTemplates implemen
         protected SafeSignedRemNode(ValueNode x, ValueNode y) {
             super(TYPE, x, y);
         }
+
         @Override
         public void generate(NodeLIRBuilderTool gen) {
             // override to ensure we always pass a null frame state
@@ -236,6 +238,7 @@ public class AArch64IntegerArithmeticSnippets extends AbstractTemplates implemen
         protected SafeUnsignedDivNode(ValueNode x, ValueNode y) {
             super(TYPE, x, y);
         }
+
         @Override
         public void generate(NodeLIRBuilderTool gen) {
             // override to ensure we always pass a null frame state
@@ -251,6 +254,7 @@ public class AArch64IntegerArithmeticSnippets extends AbstractTemplates implemen
         protected SafeUnsignedRemNode(ValueNode x, ValueNode y) {
             super(TYPE, x, y);
         }
+
         @Override
         public void generate(NodeLIRBuilderTool gen) {
             // override to ensure we always pass a null frame state

--- a/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64IntegerArithmeticSnippets.java
+++ b/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64IntegerArithmeticSnippets.java
@@ -38,6 +38,7 @@ import org.graalvm.compiler.nodes.calc.SignedRemNode;
 import org.graalvm.compiler.nodes.calc.UnsignedDivNode;
 import org.graalvm.compiler.nodes.calc.UnsignedRemNode;
 import org.graalvm.compiler.nodes.spi.LoweringTool;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 import org.graalvm.compiler.options.OptionValues;
 import org.graalvm.compiler.phases.util.Providers;
 import org.graalvm.compiler.replacements.SnippetTemplate;
@@ -205,6 +206,12 @@ public class AArch64IntegerArithmeticSnippets extends AbstractTemplates implemen
         protected SafeSignedDivNode(ValueNode x, ValueNode y) {
             super(TYPE, x, y);
         }
+        @Override
+        public void generate(NodeLIRBuilderTool gen) {
+            // override to ensure we always pass a null frame state
+            // the parent method expects to create one from a non null before state
+            gen.setResult(this, gen.getLIRGeneratorTool().getArithmetic().emitDiv(gen.operand(getX()), gen.operand(getY()), null));
+        }
     }
 
     @NodeInfo
@@ -213,6 +220,12 @@ public class AArch64IntegerArithmeticSnippets extends AbstractTemplates implemen
 
         protected SafeSignedRemNode(ValueNode x, ValueNode y) {
             super(TYPE, x, y);
+        }
+        @Override
+        public void generate(NodeLIRBuilderTool gen) {
+            // override to ensure we always pass a null frame state
+            // the parent method expects to create one from a non null before state
+            gen.setResult(this, gen.getLIRGeneratorTool().getArithmetic().emitRem(gen.operand(getX()), gen.operand(getY()), null));
         }
     }
 
@@ -223,6 +236,12 @@ public class AArch64IntegerArithmeticSnippets extends AbstractTemplates implemen
         protected SafeUnsignedDivNode(ValueNode x, ValueNode y) {
             super(TYPE, x, y);
         }
+        @Override
+        public void generate(NodeLIRBuilderTool gen) {
+            // override to ensure we always pass a null frame state
+            // the parent method expects to create one from a non null before state
+            gen.setResult(this, gen.getLIRGeneratorTool().getArithmetic().emitUDiv(gen.operand(getX()), gen.operand(getY()), null));
+        }
     }
 
     @NodeInfo
@@ -231,6 +250,12 @@ public class AArch64IntegerArithmeticSnippets extends AbstractTemplates implemen
 
         protected SafeUnsignedRemNode(ValueNode x, ValueNode y) {
             super(TYPE, x, y);
+        }
+        @Override
+        public void generate(NodeLIRBuilderTool gen) {
+            // override to ensure we always pass a null frame state
+            // the parent method expects to create one from a non null before state
+            gen.setResult(this, gen.getLIRGeneratorTool().getArithmetic().emitURem(gen.operand(getX()), gen.operand(getY()), null));
         }
     }
 


### PR DESCRIPTION
The Problem:
This patch fixes the 12 CountedLoop unit tests that currently fail with an assert during code generation.

Diagnosis:
On AArch64 DIv/Rem nodes are replaced by a snippet which includes AArch64-specific SafeDiv/Rem nodes. The latter are cloned from the original DIv/Rem nodes with a null beforeState. Unfortunately, they inherit their generate method from the generic Div/Rem nodes. The inherited methods call gen.state(this) to retrieve the beforeState and construct a FrameState passed in the call to the generators emitDiv/Rem method. This blows up because the beforeState is null.

Fix:
The AArch64 generator's emitDiv/Rem methods ignore the state argument because they will never encounter a div by zero. So, there is no need to compute a frame state. The fix works by overriding the inherited methods and passing null for the frame state.

Testing:
After this patch the 12 failing CountedLoop unit tests all succeed.