### PR TITLE
Enable trapping null checks for architectures whcih cannot fold uncompress into address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   global:
     - JVMCI_VERSION="jvmci-0.31"
     - JVMCI_BASE_JDK8="jdk1.8.0_121"
-    - JDK9_EA_BUILD="177"
+    - JDK9_EA_BUILD="178"
   matrix:
 # Cannot build OpenJDK8 based JVMCI JDK until
 # https://github.com/travis-ci/travis-ci/issues/7337 is resolved

--- a/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/UseTrappingNullChecksPhase.java
+++ b/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/UseTrappingNullChecksPhase.java
@@ -35,6 +35,7 @@ import org.graalvm.compiler.nodes.AbstractDeoptimizeNode;
 import org.graalvm.compiler.nodes.AbstractEndNode;
 import org.graalvm.compiler.nodes.AbstractMergeNode;
 import org.graalvm.compiler.nodes.BeginNode;
+import org.graalvm.compiler.nodes.CompressionNode;
 import org.graalvm.compiler.nodes.DeoptimizeNode;
 import org.graalvm.compiler.nodes.DeoptimizingFixedWithNextNode;
 import org.graalvm.compiler.nodes.DynamicDeoptimizeNode;
@@ -197,6 +198,14 @@ public class UseTrappingNullChecksPhase extends BasePhase<LowTierContext> {
                     AddressNode address = fixedAccessNode.getAddress();
                     ValueNode base = address.getBase();
                     ValueNode index = address.getIndex();
+                    // allow for architectures which cannot fold an
+                    // intervening uncompress out of the address chain
+                    if (base != null && base instanceof CompressionNode) {
+                        base = ((CompressionNode)base).getValue();
+                    }
+                    if (index != null && index instanceof CompressionNode) {
+                        index = ((CompressionNode)index).getValue();
+                    }
                     if (((base == value && index == null) || (base == null && index == value)) && address.getMaxConstantDisplacement() < implicitNullCheckLimit) {
                         // Opportunity for implicit null check as part of an existing read found!
                         fixedAccessNode.setStateBefore(deopt.stateBefore());

--- a/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/UseTrappingNullChecksPhase.java
+++ b/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/UseTrappingNullChecksPhase.java
@@ -201,10 +201,10 @@ public class UseTrappingNullChecksPhase extends BasePhase<LowTierContext> {
                     // allow for architectures which cannot fold an
                     // intervening uncompress out of the address chain
                     if (base != null && base instanceof CompressionNode) {
-                        base = ((CompressionNode)base).getValue();
+                        base = ((CompressionNode) base).getValue();
                     }
                     if (index != null && index instanceof CompressionNode) {
-                        index = ((CompressionNode)index).getValue();
+                        index = ((CompressionNode) index).getValue();
                     }
                     if (((base == value && index == null) || (base == null && index == value)) && address.getMaxConstantDisplacement() < implicitNullCheckLimit) {
                         // Opportunity for implicit null check as part of an existing read found!


### PR DESCRIPTION
The Problem:
UseTrappingNullChecksPhase checks to see whether a read from an object field is guarded by an IfNode/IsNullNode and, where possible, converts the read to use an implicit null check and splices the If out of the graph. The check involves identifying whether the oop address tested by the IsNullNode equals the oop base address used by the ReadNode. When using compressed oops this can lead to failures on architectures other than x86.

If the oop value in question is a narrow oop then the IsNullNode is passed a CompressionNode. It dereferences this to store the underlying NarrowOop value as the target value to be tested for null. If this same CompressionNode is used as the base or index for the ReadNode then the comparison will not succeed unless the address lowering can optimize the address to strip the CompressionNode and employ the underlying narrowoop as it's base or index, with a suitable base + index addressing mode.

x86 is able to do this because it can generate offset loads which also apply a shift to the input address. AArch64 can use either a base + shifted index register addressing mode or a base + offset mode but cannot combine the two (I suspect the same problem arises on SPARC?). As a result the addresss equality check always fails on AArch64 causing a NullCheckNode to be inserted. The NullCheckNode is converted to an uncompress and explicit load via the resulting address. to trigger a SEGV in case the oop is null. What is worse, the following read(s) re-execute the uncompress.

The Fix:
The fix changes the comparison to detect the situation where the input base or index address to the ReadNode is a CompressionNode, indirecting through it to locate the underlying NarrowOop base/index. This ensures that a corresponding IsNullNode guard is correctly detected even when CompressionNode folding is not possible.

Testing:
I detected this problem by eyeballing the code generated for String::equals on AArch64 and x86 where StringLatin1::equals had been inlined (using compileOnly,java.lang.String*::equals). The reads of the underlying byte arrays are both implicit null candidates.

On x86 there is no difference in before and after. On AArch64 before the fix each byte array load  was preceded by an uncompress, a null check load (with offset 0) and a 2nd uncompress feeding the byte array load (with offset 12). After the fix there was only a single uncompress preceding the byte array load. The latter served as an implicit null check (preceding uncompress was tagged with an OopMap).

I also reran unit tests on Aarch64 with no problems detected.
