### PR TITLE
Implement prefetch for AArch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   global:
     - JVMCI_VERSION="jvmci-0.28"
     - JVMCI_BASE_JDK8="jdk1.8.0_121"
-    - JDK9_EA_BUILD="174"
+    - JDK9_EA_BUILD="176"
   matrix:
 # Cannot build OpenJDK8 based JVMCI JDK until
 # https://github.com/travis-ci/travis-ci/issues/7337 is resolved
@@ -67,7 +67,7 @@ install:
       if [ "${JDK}" == "jdk9" ]
       then
         JDK_TAR=${TRAVIS_BUILD_DIR}/../jdk.tar.gz
-        wget http://download.java.net/java/jdk9/archive/${JDK9_EA_BUILD}/binaries/jdk-9-ea+${JDK9_EA_BUILD}_linux-x64_bin.tar.gz -O ${JDK_TAR}
+        wget http://download.java.net/java/jdk9/archive/${JDK9_EA_BUILD}/binaries/jdk-9+${JDK9_EA_BUILD}_linux-x64_bin.tar.gz -O ${JDK_TAR}
         tar -C ${TRAVIS_BUILD_DIR}/.. -xzf ${JDK_TAR}
         export JAVA_HOME=${TRAVIS_BUILD_DIR}/../jdk-9
       fi

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
@@ -1040,32 +1040,32 @@ public abstract class AArch64Assembler extends Assembler {
         }
 
         private static PrefetchMode[] modes = {
-                PLDL1KEEP,
-                PLDL1STRM,
-                PLDL2KEEP,
-                PLDL2STRM,
-                PLDL3KEEP,
-                PLDL3STRM,
+                        PLDL1KEEP,
+                        PLDL1STRM,
+                        PLDL2KEEP,
+                        PLDL2STRM,
+                        PLDL3KEEP,
+                        PLDL3STRM,
 
-                null,
-                null,
+                        null,
+                        null,
 
-                PLIL1KEEP,
-                PLIL1STRM,
-                PLIL2KEEP,
-                PLIL2STRM,
-                PLIL3KEEP,
-                PLIL3STRM,
+                        PLIL1KEEP,
+                        PLIL1STRM,
+                        PLIL2KEEP,
+                        PLIL2STRM,
+                        PLIL3KEEP,
+                        PLIL3STRM,
 
-                null,
-                null,
+                        null,
+                        null,
 
-                PSTL1KEEP,
-                PSTL1STRM,
-                PSTL2KEEP,
-                PSTL2STRM,
-                PSTL3KEEP,
-                PSTL3STRM
+                        PSTL1KEEP,
+                        PSTL1STRM,
+                        PSTL2KEEP,
+                        PSTL2STRM,
+                        PSTL3KEEP,
+                        PSTL3STRM
         };
 
         public PrefetchMode lookup(int encoding) {
@@ -1079,14 +1079,16 @@ public abstract class AArch64Assembler extends Assembler {
     }
 
     /*
-     * implements a prefetch at a 64-bit aligned address using a
-     * scaled 12 bit or unscaled 9 bit displacement addressing mode
+     * implements a prefetch at a 64-bit aligned address using a scaled 12 bit or unscaled 9 bit
+     * displacement addressing mode
+     * 
      * @param rt general purpose register. May not be null, zr or stackpointer.
+     * 
      * @param address only displacement addressing modes allowed. May not be null.
      */
     public void prfm(AArch64Address address, PrefetchMode mode) {
         assert (address.getAddressingMode() == AddressingMode.IMMEDIATE_SCALED ||
-                address.getAddressingMode() == AddressingMode.IMMEDIATE_UNSCALED);
+                        address.getAddressingMode() == AddressingMode.IMMEDIATE_UNSCALED);
         assert mode != null;
         final int srcSize = 64;
         final int transferSize = NumUtil.log2Ceil(srcSize / 8);

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
@@ -1088,7 +1088,8 @@ public abstract class AArch64Assembler extends Assembler {
      */
     public void prfm(AArch64Address address, PrefetchMode mode) {
         assert (address.getAddressingMode() == AddressingMode.IMMEDIATE_SCALED ||
-                        address.getAddressingMode() == AddressingMode.IMMEDIATE_UNSCALED);
+                        address.getAddressingMode() == AddressingMode.IMMEDIATE_UNSCALED ||
+                        address.getAddressingMode() == AddressingMode.REGISTER_OFFSET);
         assert mode != null;
         final int srcSize = 64;
         final int transferSize = NumUtil.log2Ceil(srcSize / 8);

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotLIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotLIRGenerator.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 
 import org.graalvm.compiler.asm.Label;
 import org.graalvm.compiler.asm.aarch64.AArch64Address.AddressingMode;
+import org.graalvm.compiler.asm.aarch64.AArch64Assembler.PrefetchMode;
 import org.graalvm.compiler.asm.aarch64.AArch64Assembler.ConditionFlag;
 import org.graalvm.compiler.core.aarch64.AArch64ArithmeticLIRGenerator;
 import org.graalvm.compiler.core.aarch64.AArch64LIRGenerator;
@@ -250,7 +251,7 @@ public class AArch64HotSpotLIRGenerator extends AArch64LIRGenerator implements H
 
     @Override
     public void emitPrefetchAllocate(Value address) {
-        append(new AArch64PrefetchOp(asAddressValue(address), config.allocatePrefetchInstr));
+        append(new AArch64PrefetchOp(asAddressValue(address), PrefetchMode.PSTL1KEEP));
     }
 
     @Override

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/JVMCIVersionCheck.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/JVMCIVersionCheck.java
@@ -121,8 +121,8 @@ class JVMCIVersionCheck {
             }
             // http://openjdk.java.net/jeps/223
             // Only support EA builds until GA is available
-            if (vmVersion.startsWith("9-ea+")) {
-                int start = "9-ea+".length();
+            if (vmVersion.startsWith("9+")) {
+                int start = "9+".length();
                 int end = start;
                 end = start;
                 while (end < vmVersion.length() && Character.isDigit(vmVersion.charAt(end))) {

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64PrefetchOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64PrefetchOp.java
@@ -25,7 +25,7 @@ package org.graalvm.compiler.lir.aarch64;
 
 import static org.graalvm.compiler.lir.LIRInstruction.OperandFlag.COMPOSITE;
 
-import org.graalvm.compiler.asm.aarch64.AArch64Address;
+import org.graalvm.compiler.asm.aarch64.AArch64Assembler.PrefetchMode;
 import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
 import org.graalvm.compiler.lir.LIRInstructionClass;
 import org.graalvm.compiler.lir.asm.CompilationResultBuilder;
@@ -33,18 +33,18 @@ import org.graalvm.compiler.lir.asm.CompilationResultBuilder;
 public final class AArch64PrefetchOp extends AArch64LIRInstruction {
     public static final LIRInstructionClass<AArch64PrefetchOp> TYPE = LIRInstructionClass.create(AArch64PrefetchOp.class);
 
-    @SuppressWarnings("unused") private final int instr;  // AllocatePrefetchInstr
+    private final PrefetchMode mode;  // AllocatePrefetchInstr
     @Alive({COMPOSITE}) protected AArch64AddressValue address;
 
-    public AArch64PrefetchOp(AArch64AddressValue address, int instr) {
+    public AArch64PrefetchOp(AArch64AddressValue address, PrefetchMode mode) {
         super(TYPE);
         this.address = address;
-        this.instr = instr;
+        this.mode = mode;
     }
 
     @Override
     public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
         // instr gets ignored!
-        masm.prfm(address.toAddress(), instr);
+        masm.prfm(address.toAddress(), mode);
     }
 }

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64PrefetchOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64PrefetchOp.java
@@ -25,6 +25,7 @@ package org.graalvm.compiler.lir.aarch64;
 
 import static org.graalvm.compiler.lir.LIRInstruction.OperandFlag.COMPOSITE;
 
+import org.graalvm.compiler.asm.aarch64.AArch64Address;
 import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
 import org.graalvm.compiler.lir.LIRInstructionClass;
 import org.graalvm.compiler.lir.asm.CompilationResultBuilder;
@@ -43,7 +44,7 @@ public final class AArch64PrefetchOp extends AArch64LIRInstruction {
 
     @Override
     public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
-        // TODO implement prefetch
-        masm.nop();
+        // instr gets ignored!
+        masm.prfm(address.toAddress(), instr);
     }
 }

--- a/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/AddressLoweringByUsePhase.java
+++ b/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/AddressLoweringByUsePhase.java
@@ -87,7 +87,7 @@ public class AddressLoweringByUsePhase extends Phase {
             } else if (node instanceof PrefetchAllocateNode) {
                 PrefetchAllocateNode prefetchAllocateNode = (PrefetchAllocateNode) node;
                 Stamp stamp = StampFactory.forKind(JavaKind.Object);
-                address = (AddressNode)prefetchAllocateNode.inputs().first();
+                address = (AddressNode) prefetchAllocateNode.inputs().first();
                 lowered = lowering.lower(prefetchAllocateNode, stamp, address);
             } else {
                 continue;

--- a/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/AddressLoweringByUsePhase.java
+++ b/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/AddressLoweringByUsePhase.java
@@ -23,8 +23,11 @@
  */
 package org.graalvm.compiler.phases.common;
 
+import jdk.vm.ci.meta.JavaKind;
 import org.graalvm.compiler.core.common.type.Stamp;
+import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.nodes.PrefetchAllocateNode;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.extended.JavaReadNode;
@@ -81,13 +84,11 @@ public class AddressLoweringByUsePhase extends Phase {
                 Stamp stamp = abstractWriteNode.value().stamp();
                 address = abstractWriteNode.getAddress();
                 lowered = lowering.lower(abstractWriteNode, stamp, address);
-                // TODO -- PrefetchAllocateNode is not yet implemented for AArch64
-                // } else if (node instanceof PrefetchAllocateNode) {
-                // PrefetchAllocateNode prefetchAllocateNode = (PrefetchAllocateNode) node;
-                // Stamp stamp = prefetchAllocateNode.value().stamp();
-                // n.b.this getter is not provided!
-                // address = prefetchAllocateNode.getAddress();
-                // lowered = lowering.lower(prefetchAllocateNode, stamp, address);
+            } else if (node instanceof PrefetchAllocateNode) {
+                PrefetchAllocateNode prefetchAllocateNode = (PrefetchAllocateNode) node;
+                Stamp stamp = StampFactory.forKind(JavaKind.Object);
+                address = (AddressNode)prefetchAllocateNode.inputs().first();
+                lowered = lowering.lower(prefetchAllocateNode, stamp, address);
             } else {
                 continue;
             }


### PR DESCRIPTION
This patch implements prefetch for AArch64.

Currently, on AArch64 a PrefetchAllocateNode inserted into generic code results in a redundant load constant followed by a nop. This patch ensures that a prefetch (prfm) instruction is generated with a suitable prefetch mode and displacement mode address.

Note that the AArch64 port does not currently set a suitable value for PrefetchAllocateInstr in it's implementation of class VM_Version. The default value of 0 (PLDL1KEEP) would not be a disaster but is not really the best choice. So, this patch follows the current AArch64 C2 compiler in enforcing use of prefetch mode PSTL1KEEP when lowering a PrefetchAllocateNode, ignoring the config setting derived from PrefetchAllocateInstr.
