### PR TITLE
test writes to direct byte buffers

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ByteBufferTest.java
+++ b/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ByteBufferTest.java
@@ -40,6 +40,7 @@ public class ByteBufferTest extends GraalCompilerTest {
         byte byteValue = 0;
         short shortValue = 0;
         int intValue = 0;
+        long longValue = 0;
         float floatValue = 0.0f;
         double doubleValue = 0.0d;
 
@@ -57,6 +58,9 @@ public class ByteBufferTest extends GraalCompilerTest {
                 return false;
             }
             if (this.intValue != other.intValue) {
+                return false;
+            }
+            if (this.longValue != other.longValue) {
                 return false;
             }
             if (Float.floatToRawIntBits(this.floatValue) != Float.floatToRawIntBits(other.floatValue)) {
@@ -98,6 +102,7 @@ public class ByteBufferTest extends GraalCompilerTest {
         ret.byteValue += buffer.get();
         ret.shortValue = buffer.getShort();
         ret.intValue = buffer.getInt();
+        ret.longValue = buffer.getLong();
         ret.doubleValue = buffer.getDouble();
         ret.floatValue = buffer.getFloat();
 
@@ -106,30 +111,31 @@ public class ByteBufferTest extends GraalCompilerTest {
 
     @Test
     public void testReadAligned() {
-        byte[] input = new byte[20];
-        for (int i = 0; i < 20; i++) {
+        byte[] input = new byte[28];
+        for (int i = 0; i < 28; i++) {
             input[i] = (byte) (7 * (i + 42));
         }
         test("alignedReadSnippet", input);
     }
 
-    byte[] alignedWriteSnippet(byte a, byte b, short c, int d, double e, float f) {
-        byte[] ret = new byte[20];
+    byte[] alignedWriteSnippet(byte a, byte b, short c, int d, long e, double f, float g) {
+        byte[] ret = new byte[28];
         ByteBuffer buffer = ByteBuffer.wrap(ret).order(byteOrder);
 
         buffer.put(a);
         buffer.put(b);
         buffer.putShort(c);
         buffer.putInt(d);
-        buffer.putDouble(e);
-        buffer.putFloat(f);
+        buffer.putLong(e);
+        buffer.putDouble(f);
+        buffer.putFloat(g);
 
         return ret;
     }
 
     @Test
     public void testWriteAligned() {
-        test("alignedWriteSnippet", (byte) 5, (byte) -3, (short) 17, 42, 84.72, 1.23f);
+        test("alignedWriteSnippet", (byte) 5, (byte) -3, (short) 17, 42, 0x3FC30A25644B7130L, 84.72, 1.23f);
     }
 
     Ret unalignedReadSnippet(byte[] arg) {
@@ -139,6 +145,7 @@ public class ByteBufferTest extends GraalCompilerTest {
         ret.byteValue = buffer.get();
         ret.shortValue = buffer.getShort();
         ret.intValue = buffer.getInt();
+        ret.longValue = buffer.getLong();
         ret.doubleValue = buffer.getDouble();
         ret.floatValue = buffer.getFloat();
 
@@ -147,28 +154,29 @@ public class ByteBufferTest extends GraalCompilerTest {
 
     @Test
     public void testReadUnaligned() {
-        byte[] input = new byte[19];
-        for (int i = 0; i < 19; i++) {
+        byte[] input = new byte[27];
+        for (int i = 0; i < 27; i++) {
             input[i] = (byte) (7 * (i + 42));
         }
         test("unalignedReadSnippet", input);
     }
 
-    byte[] unalignedWriteSnippet(byte a, short b, int c, double d, float e) {
-        byte[] ret = new byte[20];
+    byte[] unalignedWriteSnippet(byte a, short b, int c, long d, double e, float f) {
+        byte[] ret = new byte[27];
         ByteBuffer buffer = ByteBuffer.wrap(ret).order(byteOrder);
 
         buffer.put(a);
         buffer.putShort(b);
         buffer.putInt(c);
-        buffer.putDouble(d);
-        buffer.putFloat(e);
+        buffer.putLong(d);
+        buffer.putDouble(e);
+        buffer.putFloat(f);
 
         return ret;
     }
 
     @Test
     public void testWriteUnaligned() {
-        test("unalignedWriteSnippet", (byte) -3, (short) 17, 42, 84.72, 1.23f);
+        test("unalignedWriteSnippet", (byte) -3, (short) 17, 42, 0x3FC30A25644B7130L, 84.72, 1.23f);
     }
 }

--- a/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/DirectByteBufferTest.java
+++ b/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/DirectByteBufferTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.test;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class DirectByteBufferTest extends GraalCompilerTest {
+
+    class Ret {
+
+        byte byteValue = 0;
+        short shortValue = 0;
+        int intValue = 0;
+        float floatValue = 0.0f;
+        double doubleValue = 0.0d;
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof Ret)) {
+                return false;
+            }
+
+            Ret other = (Ret) obj;
+            if (this.byteValue != other.byteValue) {
+                return false;
+            }
+            if (this.shortValue != other.shortValue) {
+                return false;
+            }
+            if (this.intValue != other.intValue) {
+                return false;
+            }
+            if (Float.floatToRawIntBits(this.floatValue) != Float.floatToRawIntBits(other.floatValue)) {
+                return false;
+            }
+            if (Double.doubleToRawLongBits(this.doubleValue) != Double.doubleToRawLongBits(other.doubleValue)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("0x%02x, 0x%04x, 0x%08x, 0x%04x, 0x%08x", byteValue, shortValue, intValue, Float.floatToRawIntBits(floatValue), Double.doubleToRawLongBits(doubleValue));
+        }
+    }
+
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        ArrayList<Object[]> ret = new ArrayList<>();
+        ret.add(new Object[]{ByteOrder.BIG_ENDIAN});
+        ret.add(new Object[]{ByteOrder.LITTLE_ENDIAN});
+        return ret;
+    }
+
+    @Parameter public ByteOrder byteOrder;
+
+    Ret alignedReadSnippet(byte[] arg) {
+        ByteBuffer buffer = makeDirect(arg, byteOrder);
+
+        Ret ret = new Ret();
+        ret.byteValue = buffer.get();
+        ret.byteValue += buffer.get();
+        ret.shortValue = buffer.getShort();
+        ret.intValue = buffer.getInt();
+        ret.doubleValue = buffer.getDouble();
+        ret.floatValue = buffer.getFloat();
+
+        return ret;
+    }
+
+    @Test
+    public void testReadAligned() {
+        byte[] input = new byte[20];
+        for (int i = 0; i < 20; i++) {
+            input[i] = (byte) (7 * (i + 42));
+        }
+        test("alignedReadSnippet", input);
+    }
+
+    byte[] alignedWriteSnippet(byte a, byte b, short c, int d, double e, float f) {
+        byte[] ret = new byte[20];
+        ByteBuffer buffer = makeDirect(20, byteOrder);
+
+        buffer.put(a);
+        buffer.put(b);
+        buffer.putShort(c);
+        buffer.putInt(d);
+        buffer.putDouble(e);
+        buffer.putFloat(f);
+
+        buffer.position(0);
+        buffer.get(ret);
+
+        return ret;
+    }
+
+    @Test
+    public void testWriteAligned() {
+        test("alignedWriteSnippet", (byte) 5, (byte) -3, (short) 17, 42, 84.72, 1.23f);
+    }
+
+    Ret unalignedReadSnippet(byte[] arg) {
+        ByteBuffer buffer = makeDirect(arg, byteOrder);
+
+        Ret ret = new Ret();
+        ret.byteValue = buffer.get();
+        ret.shortValue = buffer.getShort();
+        ret.intValue = buffer.getInt();
+        ret.doubleValue = buffer.getDouble();
+        ret.floatValue = buffer.getFloat();
+
+        return ret;
+    }
+
+    @Test
+    public void testReadUnaligned() {
+        byte[] input = new byte[19];
+        for (int i = 0; i < 19; i++) {
+            input[i] = (byte) (7 * (i + 42));
+        }
+        test("unalignedReadSnippet", input);
+    }
+
+    byte[] unalignedWriteSnippet(byte a, short b, int c, double d, float e) {
+        byte[] ret = new byte[20];
+        ByteBuffer buffer = makeDirect(20, byteOrder);
+
+        buffer.put(a);
+        buffer.putShort(b);
+        buffer.putInt(c);
+        buffer.putDouble(d);
+        buffer.putFloat(e);
+
+        buffer.position(0);
+        buffer.get(ret);
+
+        return ret;
+    }
+
+    @Test
+    public void testWriteUnaligned() {
+        test("unalignedWriteSnippet", (byte) -3, (short) 17, 42, 84.72, 1.23f);
+    }
+
+    private ByteBuffer makeDirect(byte[] bytes, ByteOrder byteOrder) {
+        int length = bytes.length;
+        ByteBuffer buffer = ByteBuffer.allocateDirect(length).order(byteOrder);
+        buffer.put(bytes);
+        buffer.position(0);
+        return buffer;
+    }
+
+    private ByteBuffer makeDirect(int length, ByteOrder byteOrder) {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(length).order(byteOrder);
+        buffer.position(0);
+        return buffer;
+    }
+}


### PR DESCRIPTION
As promised here is a unit test to check writes to direct byte buffers, It passes on x86 and AArch64 with the latest head.

n.b. I reverted the AArch64 address lowering code to revert the fix that updated usages one by one and, as expected, the unaligned int writes failed because the second byte of the int was being written at offset 1 rather than offset 2. So, this test would have caught the error in the original commit.