### PR TITLE
use scaled addressing in preference to unscaled where possible

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
@@ -146,10 +146,10 @@ public class AArch64MacroAssembler extends AArch64Assembler {
                     return new AddressGenerationPlan(ADD_TO_BASE, REGISTER_OFFSET, needsScratch);
                 }
             } else {
-                if (NumUtil.isSignedNbit(9, displacement)) {
-                    return new AddressGenerationPlan(NO_WORK, IMMEDIATE_UNSCALED, false);
-                } else if (displacementScalable && NumUtil.isUnsignedNbit(12, scaledDisplacement)) {
+                if (displacementScalable && NumUtil.isUnsignedNbit(12, scaledDisplacement)) {
                     return new AddressGenerationPlan(NO_WORK, IMMEDIATE_SCALED, false);
+                } else if (NumUtil.isSignedNbit(9, displacement)) {
+                    return new AddressGenerationPlan(NO_WORK, IMMEDIATE_UNSCALED, false);
                 } else {
                     boolean needsScratch = !isArithmeticImmediate(displacement);
                     return new AddressGenerationPlan(ADD_TO_BASE, REGISTER_OFFSET, needsScratch);


### PR DESCRIPTION
What?
This patch changes the address generation plan for AArch64 to use scaled displacement addressing in preference to unscaled displacement addressing. It's only a cosmetic change since neither is better than the other in terms of how the code executes, yet it seems cosmetics do have a point.

Why?
Unscaled addressing generates an instruction ldur xr, [xm,#nnn] where nnn is a 9-bit signed unscaled displacement (offsets from -2^9 inclusive up to 2^9 exclusive). Scaled addressing generates an instruction ldr xr, [xm, #nnn] where nnn is a 12 bit unsigned scaled displacement (i.e. byte offsets up to 2^12, qword aligned offsets up to 2^15). For any positive nnn value fitting into 8 bits there is no difference between the two instructions except for the presence of ldur/ldr. Outside that range (negative <= 2^9 or positive between 2^9 and 2^15) there is no option to choose between ldr or ldur.

Stack loads and object field loads always use a positive displacement. So, with the present preference offsets which can be embedded as displacements switch generation from employing ldur to ldr when the (scaled) displacement exceeds the 8 bit limit. Changing the address plan to prefer scaled addressing means that all stack and object loads which can use a displacement are generated as ldr, making it easier to read generated code.

Testing:
All unit tests pass after this change. I also ran netbeans as a smoke test and encountered no problems.
