### PR TITLE
AArch64 Zero/SignExtend elision is inadequate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   global:
     - JVMCI_VERSION="jvmci-0.31"
     - JVMCI_BASE_JDK8="jdk1.8.0_121"
-    - JDK9_EA_BUILD="177"
+    - JDK9_EA_BUILD="178"
   matrix:
 # Cannot build OpenJDK8 based JVMCI JDK until
 # https://github.com/travis-ci/travis-ci/issues/7337 is resolved

--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -331,7 +331,6 @@ suite = {
       "subDir" : "src",
       "sourceDirs" : ["src"],
       "dependencies" : [
-        "org.graalvm.compiler.core.aarch64",
         "org.graalvm.compiler.hotspot",
         "org.graalvm.compiler.replacements.aarch64",
       ],
@@ -695,7 +694,6 @@ suite = {
       "sourceDirs" : ["src"],
       "dependencies" : [
         "org.graalvm.compiler.replacements",
-        "org.graalvm.compiler.lir.aarch64",
         "org.graalvm.compiler.core.aarch64",
       ],
       "checkstyle" : "org.graalvm.compiler.graph",

--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -696,6 +696,7 @@ suite = {
       "dependencies" : [
         "org.graalvm.compiler.replacements",
         "org.graalvm.compiler.lir.aarch64",
+        "org.graalvm.compiler.core.aarch64",
       ],
       "checkstyle" : "org.graalvm.compiler.graph",
       "javaCompliance" : "1.8",

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
@@ -94,7 +94,7 @@ public class AArch64ArithmeticLIRGenerator extends ArithmeticLIRGenerator implem
         }
     }
 
-    protected Value emitExtendMemory(boolean isSigned, AArch64Kind memoryKind, int resultBits, AArch64AddressValue address, LIRFrameState state) {
+    public Value emitExtendMemory(boolean isSigned, AArch64Kind memoryKind, int resultBits, AArch64AddressValue address, LIRFrameState state) {
         // Issue a zero extending load of the proper bit size and set the result to
         // the proper kind.
         Variable result = getLIRGen().newVariable(LIRKind.value(resultBits == 32 ? AArch64Kind.DWORD : AArch64Kind.QWORD));

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
@@ -61,7 +61,7 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
     protected AArch64ArithmeticLIRGenerator getArithmeticLIRGenerator() {
         return (AArch64ArithmeticLIRGenerator) getLIRGeneratorTool().getArithmetic();
     }
-
+    /*
     @MatchRule("(ZeroExtend Read=access)")
     @MatchRule("(ZeroExtend FloatingRead=access)")
     public ComplexMatchResult zeroExtend(ZeroExtendNode root, Access access) {
@@ -75,4 +75,5 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
         AArch64Kind memoryKind = getMemoryKind(access);
         return builder -> getArithmeticLIRGenerator().emitExtendMemory(true, memoryKind, root.getResultBits(), (AArch64AddressValue) operand(access.getAddress()), getState(access));
     }
+    */
 }

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
@@ -24,14 +24,9 @@
 package org.graalvm.compiler.core.aarch64;
 
 import org.graalvm.compiler.core.gen.NodeMatchRules;
-import org.graalvm.compiler.core.match.ComplexMatchResult;
-import org.graalvm.compiler.core.match.MatchRule;
 import org.graalvm.compiler.lir.LIRFrameState;
-import org.graalvm.compiler.lir.aarch64.AArch64AddressValue;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
 import org.graalvm.compiler.nodes.DeoptimizingNode;
-import org.graalvm.compiler.nodes.calc.SignExtendNode;
-import org.graalvm.compiler.nodes.calc.ZeroExtendNode;
 import org.graalvm.compiler.nodes.memory.Access;
 
 import jdk.vm.ci.aarch64.AArch64Kind;
@@ -61,19 +56,4 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
     protected AArch64ArithmeticLIRGenerator getArithmeticLIRGenerator() {
         return (AArch64ArithmeticLIRGenerator) getLIRGeneratorTool().getArithmetic();
     }
-    /*
-    @MatchRule("(ZeroExtend Read=access)")
-    @MatchRule("(ZeroExtend FloatingRead=access)")
-    public ComplexMatchResult zeroExtend(ZeroExtendNode root, Access access) {
-        AArch64Kind memoryKind = getMemoryKind(access);
-        return builder -> getArithmeticLIRGenerator().emitExtendMemory(false, memoryKind, root.getResultBits(), (AArch64AddressValue) operand(access.getAddress()), getState(access));
-    }
-
-    @MatchRule("(SignExtend Read=access)")
-    @MatchRule("(SignExtend FloatingRead=access)")
-    public ComplexMatchResult signExtend(SignExtendNode root, Access access) {
-        AArch64Kind memoryKind = getMemoryKind(access);
-        return builder -> getArithmeticLIRGenerator().emitExtendMemory(true, memoryKind, root.getResultBits(), (AArch64AddressValue) operand(access.getAddress()), getState(access));
-    }
-    */
 }

--- a/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ZeroSignExtendTest.java
+++ b/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ZeroSignExtendTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/*
+ * Test compilation of ZeroExtend and SignExtend nodes
+ */
+
+public class ZeroSignExtendTest extends GraalCompilerTest {
+
+    int testSnippet1(char[] chars) {
+        int x = 1;
+        x += chars[0];
+        x -= chars[1];
+        x *= chars[2];
+        x /= chars[3];
+        x &= chars[4];
+        x |= chars[5];
+        x ^= chars[6];
+        x <<= chars[7];
+        x >>= (chars[8] - chars[0]);
+        x >>>= (chars[9] - chars[0]);
+        x += chars[1];
+        return x;
+    }
+
+    long testSnippet2(char[] chars) {
+        long y = 2;
+        y += chars[0];
+        y -= chars[1];
+        y *= chars[2];
+        y /= chars[3];
+        y &= chars[4];
+        y |= chars[5];
+        y ^= chars[6];
+        y <<= chars[7];
+        y >>= (chars[8] - chars[0]);
+        y >>>= (chars[9] - chars[0]);
+        y += chars[1];
+        return y;
+    }
+
+    int testSnippet3(short[] shorts) {
+        int x = 1;
+        x += shorts[0];
+        x -= shorts[1];
+        x *= shorts[2];
+        x /= shorts[3];
+        x &= shorts[4];
+        x |= shorts[5];
+        x ^= shorts[6];
+        x <<= shorts[7];
+        x >>= (shorts[8] - shorts[0]);
+        x >>>= (shorts[9] - shorts[0]);
+        x += shorts[1];
+        return x;
+    }
+
+    long testSnippet4(short[] shorts) {
+        long y = 2;
+        y += shorts[0];
+        y -= shorts[1];
+        y *= shorts[2];
+        y /= shorts[3];
+        y &= shorts[4];
+        y |= shorts[5];
+        y ^= shorts[6];
+        y <<= shorts[7];
+        y >>= (shorts[8] - shorts[0]);
+        y >>>= (shorts[9] - shorts[0]);
+        y += shorts[1];
+        return y;
+    }
+
+    int testSnippet5(byte[] bytes) {
+        int x = 1;
+        x += bytes[0];
+        x -= bytes[1];
+        x *= bytes[2];
+        x /= bytes[3];
+        x &= bytes[4];
+        x |= bytes[5];
+        x ^= bytes[6];
+        x <<= bytes[7];
+        x >>= (bytes[8] - bytes[0]);
+        x >>>= (bytes[9] - bytes[0]);
+        x += bytes[1];
+        return x;
+    }
+
+    long testSnippet6(byte[] bytes) {
+        long y = 2;
+        y += bytes[0];
+        y -= bytes[1];
+        y *= bytes[2];
+        y /= bytes[3];
+        y &= bytes[4];
+        y |= bytes[5];
+        y ^= bytes[6];
+        y <<= bytes[7];
+        y >>= (bytes[8] - bytes[0]);
+        y >>>= (bytes[9] - bytes[0]);
+        y += bytes[1];
+        return y;
+    }
+
+    @Test
+
+    public void test() {
+        char[] input1 = new char[]{'0', '1', '2', '3', '4', '5', '7', '8', '9', 'A'};
+        char[] input2 = new char[]{'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K'};
+
+        short[] input3 = new short[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        short[] input4 = new short[]{11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
+
+        byte[] input5 = new byte[]{21, 22, 23, 24, 25, 26, 27, 28, 29, 30};
+        byte[] input6 = new byte[]{11, 12, 13, 14, 15, 16, 17, 18, 19, 40};
+
+        test("testSnippet1", input1);
+        test("testSnippet2", input2);
+        test("testSnippet3", input3);
+        test("testSnippet4", input4);
+        test("testSnippet5", input5);
+        test("testSnippet6", input6);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotSuitesProvider.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotSuitesProvider.java
@@ -62,7 +62,7 @@ public class AArch64HotSpotSuitesProvider extends HotSpotSuitesProvider {
         }
         findPhase.add(new AddressLoweringByUsePhase(addressLoweringByUse));
 
-        findPhase =  suites.getLowTier().findPhase(PropagateDeoptimizeProbabilityPhase.class);
+        findPhase = suites.getLowTier().findPhase(PropagateDeoptimizeProbabilityPhase.class);
         findPhase.add(new AArch64ReadReplacementPhase());
 
         return suites;

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotSuitesProvider.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotSuitesProvider.java
@@ -31,9 +31,11 @@ import org.graalvm.compiler.phases.BasePhase;
 import org.graalvm.compiler.phases.common.AddressLoweringByUsePhase;
 import org.graalvm.compiler.phases.common.ExpandLogicPhase;
 import org.graalvm.compiler.phases.common.FixReadsPhase;
+import org.graalvm.compiler.phases.common.PropagateDeoptimizeProbabilityPhase;
 import org.graalvm.compiler.phases.tiers.LowTierContext;
 import org.graalvm.compiler.phases.tiers.Suites;
 import org.graalvm.compiler.phases.tiers.SuitesCreator;
+import org.graalvm.compiler.replacements.aarch64.AArch64ReadReplacementPhase;
 
 import java.util.ListIterator;
 
@@ -59,6 +61,9 @@ public class AArch64HotSpotSuitesProvider extends HotSpotSuitesProvider {
             findPhase = suites.getLowTier().findPhase(ExpandLogicPhase.class);
         }
         findPhase.add(new AddressLoweringByUsePhase(addressLoweringByUse));
+
+        findPhase =  suites.getLowTier().findPhase(PropagateDeoptimizeProbabilityPhase.class);
+        findPhase.add(new AArch64ReadReplacementPhase());
 
         return suites;
     }

--- a/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64ReadNode.java
+++ b/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64ReadNode.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package org.graalvm.compiler.replacements.aarch64;
 
 import jdk.vm.ci.aarch64.AArch64Kind;
@@ -20,35 +44,35 @@ import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 import org.graalvm.word.LocationIdentity;
 
 /**
- * AArch64-specific subclass of ReadNode that knows hwo to merge ZeroExtend and SignExtend into the read
+ * AArch64-specific subclass of ReadNode that knows how to merge ZeroExtend and SignExtend into the
+ * read.
  */
 
 @NodeInfo
-public class AArch64ReadNode extends ReadNode
-{
+public class AArch64ReadNode extends ReadNode {
     public static final NodeClass<AArch64ReadNode> TYPE = NodeClass.create(AArch64ReadNode.class);
     private final IntegerStamp accessStamp;
     private final boolean isSigned;
 
     public AArch64ReadNode(AddressNode address, LocationIdentity location, Stamp stamp, GuardingNode guard, BarrierType barrierType, boolean nullCheck,
-                           FrameState stateBefore, IntegerStamp accessStamp, boolean isSigned) {
+                    FrameState stateBefore, IntegerStamp accessStamp, boolean isSigned) {
         super(TYPE, address, location, stamp, guard, barrierType, nullCheck, stateBefore);
         this.accessStamp = accessStamp;
         this.isSigned = isSigned;
     }
+
     @Override
     public void generate(NodeLIRBuilderTool gen) {
         AArch64LIRGenerator lirgen = (AArch64LIRGenerator) gen.getLIRGeneratorTool();
         AArch64ArithmeticLIRGenerator arithgen = (AArch64ArithmeticLIRGenerator) lirgen.getArithmetic();
         AArch64Kind readKind = (AArch64Kind) lirgen.getLIRKind(accessStamp).getPlatformKind();
-        int resultBits = ((IntegerStamp)stamp()).getBits();
+        int resultBits = ((IntegerStamp) stamp()).getBits();
         gen.setResult(this, arithgen.emitExtendMemory(isSigned, readKind, resultBits, (AArch64AddressValue) gen.operand(getAddress()), gen.state(this)));
     }
 
     /**
-     * replace a ReadNode with an AArch64-specific variant
-     * which knows how to merge a downstream zero or sign
-     * extend into the read operation
+     * replace a ReadNode with an AArch64-specific variant which knows how to merge a downstream
+     * zero or sign extend into the read operation.
      *
      * @param readNode
      * @return the replacement node
@@ -57,9 +81,9 @@ public class AArch64ReadNode extends ReadNode
         assert readNode.getUsageCount() == 1;
         assert readNode.getUsageAt(0) instanceof ZeroExtendNode || readNode.getUsageAt(0) instanceof SignExtendNode;
 
-        ValueNode usage =  (ValueNode) readNode.getUsageAt(0);
+        ValueNode usage = (ValueNode) readNode.getUsageAt(0);
         boolean isSigned = usage instanceof SignExtendNode;
-        IntegerStamp accessStamp = ((IntegerStamp)readNode.getAccessStamp());
+        IntegerStamp accessStamp = ((IntegerStamp) readNode.getAccessStamp());
 
         AddressNode address = readNode.getAddress();
         LocationIdentity location = readNode.getLocationIdentity();
@@ -68,7 +92,7 @@ public class AArch64ReadNode extends ReadNode
         BarrierType barrierType = readNode.getBarrierType();
         boolean nullCheck = readNode.getNullCheck();
         FrameState stateBefore = readNode.stateBefore();
-        AArch64ReadNode clone = new  AArch64ReadNode(address, location, stamp, guard, barrierType, nullCheck, stateBefore, accessStamp, isSigned);
+        AArch64ReadNode clone = new AArch64ReadNode(address, location, stamp, guard, barrierType, nullCheck, stateBefore, accessStamp, isSigned);
         StructuredGraph graph = readNode.graph();
         graph.add(clone);
         // splice out the extend node

--- a/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64ReadNode.java
+++ b/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64ReadNode.java
@@ -1,0 +1,79 @@
+package org.graalvm.compiler.replacements.aarch64;
+
+import jdk.vm.ci.aarch64.AArch64Kind;
+import org.graalvm.compiler.core.aarch64.AArch64ArithmeticLIRGenerator;
+import org.graalvm.compiler.core.aarch64.AArch64LIRGenerator;
+import org.graalvm.compiler.core.common.type.IntegerStamp;
+import org.graalvm.compiler.core.common.type.Stamp;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.aarch64.AArch64AddressValue;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.FrameState;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.calc.SignExtendNode;
+import org.graalvm.compiler.nodes.calc.ZeroExtendNode;
+import org.graalvm.compiler.nodes.extended.GuardingNode;
+import org.graalvm.compiler.nodes.memory.ReadNode;
+import org.graalvm.compiler.nodes.memory.address.AddressNode;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import org.graalvm.word.LocationIdentity;
+
+/**
+ * AArch64-specific subclass of ReadNode that knows hwo to merge ZeroExtend and SignExtend into the read
+ */
+
+@NodeInfo
+public class AArch64ReadNode extends ReadNode
+{
+    public static final NodeClass<AArch64ReadNode> TYPE = NodeClass.create(AArch64ReadNode.class);
+    private final IntegerStamp accessStamp;
+    private final boolean isSigned;
+
+    public AArch64ReadNode(AddressNode address, LocationIdentity location, Stamp stamp, GuardingNode guard, BarrierType barrierType, boolean nullCheck,
+                           FrameState stateBefore, IntegerStamp accessStamp, boolean isSigned) {
+        super(TYPE, address, location, stamp, guard, barrierType, nullCheck, stateBefore);
+        this.accessStamp = accessStamp;
+        this.isSigned = isSigned;
+    }
+    @Override
+    public void generate(NodeLIRBuilderTool gen) {
+        AArch64LIRGenerator lirgen = (AArch64LIRGenerator) gen.getLIRGeneratorTool();
+        AArch64ArithmeticLIRGenerator arithgen = (AArch64ArithmeticLIRGenerator) lirgen.getArithmetic();
+        AArch64Kind readKind = (AArch64Kind) lirgen.getLIRKind(accessStamp).getPlatformKind();
+        int resultBits = ((IntegerStamp)stamp()).getBits();
+        gen.setResult(this, arithgen.emitExtendMemory(isSigned, readKind, resultBits, (AArch64AddressValue) gen.operand(getAddress()), gen.state(this)));
+    }
+
+    /**
+     * replace a ReadNode with an AArch64-specific variant
+     * which knows how to merge a downstream zero or sign
+     * extend into the read operation
+     *
+     * @param readNode
+     * @return the replacement node
+     */
+    public static void replace(ReadNode readNode) {
+        assert readNode.getUsageCount() == 1;
+        assert readNode.getUsageAt(0) instanceof ZeroExtendNode || readNode.getUsageAt(0) instanceof SignExtendNode;
+
+        ValueNode usage =  (ValueNode) readNode.getUsageAt(0);
+        boolean isSigned = usage instanceof SignExtendNode;
+        IntegerStamp accessStamp = ((IntegerStamp)readNode.getAccessStamp());
+
+        AddressNode address = readNode.getAddress();
+        LocationIdentity location = readNode.getLocationIdentity();
+        Stamp stamp = usage.stamp();
+        GuardingNode guard = readNode.getGuard();
+        BarrierType barrierType = readNode.getBarrierType();
+        boolean nullCheck = readNode.getNullCheck();
+        FrameState stateBefore = readNode.stateBefore();
+        AArch64ReadNode clone = new  AArch64ReadNode(address, location, stamp, guard, barrierType, nullCheck, stateBefore, accessStamp, isSigned);
+        StructuredGraph graph = readNode.graph();
+        graph.add(clone);
+        // splice out the extend node
+        usage.replaceAtUsagesAndDelete(readNode);
+        // swap the clone for the read
+        graph.replaceFixedWithFixed(readNode, clone);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64ReadReplacementPhase.java
+++ b/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64ReadReplacementPhase.java
@@ -1,4 +1,29 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package org.graalvm.compiler.replacements.aarch64;
+
 import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.calc.SignExtendNode;
@@ -7,14 +32,13 @@ import org.graalvm.compiler.nodes.memory.ReadNode;
 import org.graalvm.compiler.phases.Phase;
 
 /**
- * AArch64-specific phase which substitutes certain read nodes
- * with arch-specific variants in order to allow merging of
- * zero and sign extension into the read operation
+ * AArch64-specific phase which substitutes certain read nodes with arch-specific variants in order
+ * to allow merging of zero and sign extension into the read operation.
  */
+
 public class AArch64ReadReplacementPhase extends Phase {
     @Override
-    protected void run(StructuredGraph graph)
-    {
+    protected void run(StructuredGraph graph) {
         for (Node node : graph.getNodes()) {
             // don't process nodes we just added
             if (node instanceof AArch64ReadNode) {

--- a/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64ReadReplacementPhase.java
+++ b/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64ReadReplacementPhase.java
@@ -1,0 +1,34 @@
+package org.graalvm.compiler.replacements.aarch64;
+import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.calc.SignExtendNode;
+import org.graalvm.compiler.nodes.calc.ZeroExtendNode;
+import org.graalvm.compiler.nodes.memory.ReadNode;
+import org.graalvm.compiler.phases.Phase;
+
+/**
+ * AArch64-specific phase which substitutes certain read nodes
+ * with arch-specific variants in order to allow merging of
+ * zero and sign extension into the read operation
+ */
+public class AArch64ReadReplacementPhase extends Phase {
+    @Override
+    protected void run(StructuredGraph graph)
+    {
+        for (Node node : graph.getNodes()) {
+            // don't process nodes we just added
+            if (node instanceof AArch64ReadNode) {
+                continue;
+            }
+            if (node instanceof ReadNode) {
+                ReadNode readNode = (ReadNode) node;
+                if (readNode.getUsageCount() == 1) {
+                    Node usage = readNode.getUsageAt(0);
+                    if (usage instanceof ZeroExtendNode || usage instanceof SignExtendNode) {
+                        AArch64ReadNode.replace(readNode);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This patch fixes the problem reported here: https://github.com/graalvm/graal/issues/238

When running on AArch64 it adds a phase to the LowTier  just before the Scheduling phase. This new phase replaces pairs of Read + Sign/ZeroExtend nodes with an AArch64ReadNode that combines the read and extend operation into one.

The patch includes a unit test (ZeroSignExtendTest) which exercises the node replacement for the newly added phase. Generated code for the test snippets before and after the patch shows that the patched version elides redundant stxw or andw instructions that the previous match rules could not eliminate.

Atached assembler dumps for the before and after code show the improvement.
[extend-before.txt](https://github.com/graalvm/graal/files/1142318/extend-before.txt)
[extend-after.txt](https://github.com/graalvm/graal/files/1142317/extend-after.txt)

